### PR TITLE
Allow Updates of ZAR's plugins in the DICE IDE

### DIFF
--- a/org.dice.root/features/org.dice.features.profiles/feature.xml
+++ b/org.dice.root/features/org.dice.features.profiles/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.dice.features.profiles"
       label="DICE Profiles Feature"
-      version="0.5.0.qualifier"
+      version="0.1.0.qualifier"
       provider-name="DICE Project">
 
    <description url="https://vm-project-dice.doc.ic.ac.uk/redmine/projects/dice">
@@ -221,27 +221,9 @@ litigation
 
    <requires>
       <import feature="org.dice.features.papyrus" version="2.0.0.qualifier"/>
+      <import feature="com.masdes.dam.profile"/>
+      <import feature="com.masdes.dam.profile.ui.feature"/>
+      <import feature="es.unizar.disco.dice.profile.feature"/>
    </requires>
-
-   <plugin
-         id="com.masdes.dam.static.profile"
-         download-size="0"
-         install-size="0"
-         version="0.5.0.201606231611"
-         unpack="false"/>
-
-   <plugin
-         id="com.masdes.dam.static.profile.ui"
-         download-size="0"
-         install-size="0"
-         version="0.5.0.201606231611"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.dice.static.profile"
-         download-size="0"
-         install-size="0"
-         version="0.5.0.201606231611"
-         unpack="false"/>
 
 </feature>

--- a/org.dice.root/features/org.dice.features.simulation/feature.xml
+++ b/org.dice.root/features/org.dice.features.simulation/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.dice.features.simulation"
       label="DICE Simulation Feature"
-      version="0.1.6.qualifier"
+      version="0.1.0.qualifier"
       provider-name="DICE Project">
 
    <description url="https://vm-project-dice.doc.ic.ac.uk/redmine/projects/dice">
@@ -223,110 +223,21 @@ litigation
       <import feature="org.dice.features.acceleo" version="3.6.4.qualifier"/>
       <import feature="org.dice.features.pnml" version="2.2.12.qualifier"/>
       <import feature="org.dice.features.profiles" version="0.5.0.qualifier"/>
+      <import feature="es.unizar.disco.simulation.feature"/>
+      <import feature="es.unizar.disco.simulation.greatspn.feature"/>
+      <import feature="es.unizar.disco.simulation.quickstart.feature"/>
+      <import feature="es.unizar.disco.simulation.ui.feature"/>
+      <import feature="es.unizar.disco.ssh.feature"/>
+      <import feature="es.unizar.dsico.ssh.ui.feature"/>
+      <import feature="com.hierynomus.sshj.feature"/>
+      <import feature="org.dice.features.papyrus" version="2.0.0.qualifier"/>
    </requires>
-
-   <plugin
-         id="es.unizar.disco.simulation"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.simulation.greatspn.ssh"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.simulation.quickstart"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.simulation.ui"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.core"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.core.ui"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.pnconfig"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.pnextensions"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.pnml.m2m"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.pnml.m2t"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.ssh"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="es.unizar.disco.ssh.ui"
-         download-size="0"
-         install-size="0"
-         version="0.1.6.201604081552"
-         unpack="false"/>
-
-   <plugin
-         id="com.hierynomus.sshj"
-         download-size="0"
-         install-size="0"
-         version="0.15.0.201602161613"/>
-
-   <plugin
-         id="org.eclipse.ui.intro.universal"
-         download-size="0"
-         install-size="0"
-         version="3.3.0.v20160519-1604"
-         unpack="false"/>
 
    <plugin
          id="org.dice.simulation"
          download-size="0"
          install-size="0"
-         version="0.1.0.qualifier"
+         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/org.dice.root/releng/org.dice.configuration/pom.xml
+++ b/org.dice.root/releng/org.dice.configuration/pom.xml
@@ -27,7 +27,7 @@
 		<subclipse.url>http://subclipse.tigris.org/update_1.12.x</subclipse.url>
 		<egit.url>http://download.eclipse.org/egit/updates</egit.url>
 		<ecf.url>http://download.eclipse.org/rt/ecf/3.13.1/site.p2/</ecf.url>
-		<pnml.url>http://pnml.lip6.fr/pnmlframework/updatesite/2.2.12/</pnml.url>
+		<pnml.url>http://pnml.lip6.fr/pnmlframework/updatesite/</pnml.url>
 		<dice-deployment.url>http://dice-project.github.io/DICE-Deployment-IDE-Plugin</dice-deployment.url>
 		<dice-verification.url>http://dice-project.github.io/DICE-Verification/updates</dice-verification.url>
 		<dice-profiles.url>http://dice-project.github.io/DICE-Profiles/updates</dice-profiles.url>

--- a/org.dice.root/releng/org.dice.product/dice.product
+++ b/org.dice.root/releng/org.dice.product/dice.product
@@ -80,6 +80,11 @@ org.eclipse.papyrus.infra.core.perspective
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
    </configurations>
 
+   <repositories>
+      <repository location="http://dice-project.github.io/DICE-Profiles/updates" enabled="true" />
+      <repository location="http://dice-project.github.io/DICE-Simulation/updates" enabled="true" />
+   </repositories>
+
    <preferencesInfo>
       <targetfile overwrite="false"/>
    </preferencesInfo>

--- a/org.dice.root/releng/org.dice.product/dice.product
+++ b/org.dice.root/releng/org.dice.product/dice.product
@@ -37,9 +37,9 @@ org.eclipse.papyrus.infra.core.perspective
       <solaris/>
       <win useIco="true">
          <ico path="icons/icon.ico"/>
+         <bmp/>
       </win>
    </launcher>
-
 
    <vm>
    </vm>
@@ -54,12 +54,12 @@ org.eclipse.papyrus.infra.core.perspective
       <feature id="org.dice.features.uml2" version="5.2.0.qualifier"/>
       <feature id="org.dice.features.wst" version="3.8.0.qualifier"/>
       <feature id="org.dice.features.jdt" version="3.12.0.qualifier"/>
-      <feature id="org.dice.features.simulation" version="0.1.6.qualifier"/>
+      <feature id="org.dice.features.simulation" version="0.1.0.qualifier"/>
       <feature id="org.dice.features.acceleo" version="3.6.4.qualifier"/>
       <feature id="org.dice.features.papyrus" version="2.0.0.qualifier"/>
       <feature id="org.dice.features.xtext" version="2.10.0.qualifier"/>
       <feature id="org.dice.features.qvto" version="3.6.0.qualifier"/>
-      <feature id="org.dice.features.profiles" version="0.5.0.qualifier"/>
+      <feature id="org.dice.features.profiles" version="0.1.0.qualifier"/>
       <feature id="org.dice.features.pnml" version="2.2.12.qualifier"/>
       <feature id="org.dice.features.atl" version="3.6.0.qualifier"/>
       <feature id="org.dice.features.svn" version="1.12.10.qualifier"/>


### PR DESCRIPTION
This modifications allows updating the plugins developed by ZAR (i.e., DICE Profiles and DICE Simulation Tool) in the DICE IDE.

This is done by converting included plugins with specific versions into dependencies to the last available versions in the update sites.

Additionally, since the versions of the plugins are unknown _a priori_, the versions of the container features `org.dice.features.profiles` and `org.dice.features.simulation` have been changed to be in line with the product version 0.1.0.
